### PR TITLE
add com.github.miguelmota.Cointop

### DIFF
--- a/com.github.miguelmota.Cointop.json
+++ b/com.github.miguelmota.Cointop.json
@@ -1,0 +1,26 @@
+{
+  "app-id": "com.github.miguelmota.Cointop",
+  "runtime": "org.freedesktop.Platform",
+  "runtime-version": "1.6",
+  "sdk": "org.freedesktop.Sdk",
+  "command": "cointop",
+  "modules": [
+    {
+      "name": "cointop",
+      "buildsystem": "simple",
+      "build-commands": [
+        "install -D bin/linux/cointop /app/bin/cointop"
+      ],
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/miguelmota/cointop.git"
+        }
+      ]
+    }
+  ],
+  "finish-args": [
+     "--filesystem=home",
+     "--share=network"
+  ]
+}


### PR DESCRIPTION
Adds [cointop](https://github.com/miguelmota/cointop) to flathub

Cointop is a simple terminal based application for tracking cryptocurrencies

Requires the home directory for storing configuration files, and network access for making HTTP requests

I'm new to flatpak; please let me know if it needs improvement

Thanks!